### PR TITLE
Fix basic_window_web compile flags

### DIFF
--- a/core/basic_window_web.nims
+++ b/core/basic_window_web.nims
@@ -18,7 +18,7 @@ when defined(emscripten):
     --clang.cpp.exe:emcc
     --clang.cpp.linkerexe:emcc
   # --mm:orc
-  --threads:on
+  --threads:off
   --panics:on
   --define:noSignalHandler
   --passL:"-o public/index.html"

--- a/core/basic_window_web.nims
+++ b/core/basic_window_web.nims
@@ -24,3 +24,4 @@ when defined(emscripten):
   --passL:"-o public/index.html"
   # Use raylib/src/shell.html or raylib/src/minshell.html
   --passL:"--shell-file shell_minimal.html"
+  --passL:"-sEXPORTED_RUNTIME_METHODS=requestFullscreen"


### PR DESCRIPTION
See:

* https://github.com/planetis-m/naylib/issues/175#issuecomment-3186911073
* https://emscripten.org/docs/getting_started/FAQ.html#why-do-i-get-typeerror-module-something-is-not-a-function

for rationale.